### PR TITLE
Fix: changing request_queue_id everytime!

### DIFF
--- a/hivemind_etl/website/crawlee_client.py
+++ b/hivemind_etl/website/crawlee_client.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Any
+import uuid
 
 from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingContext
 from defusedxml import ElementTree as ET
@@ -21,6 +22,12 @@ class CrawleeClient:
         # do not persist crawled data to local storage
         self.crawler._configuration.persist_storage = False
         self.crawler._configuration.write_metadata = False
+        self.crawler._configuration.purge_on_start = True
+
+        # changing the id each time so it wouldn't continue
+        # fetching the previous links
+        config = self.crawler._configuration.get_global_configuration()
+        config.default_request_queue_id = uuid.uuid4().hex
 
         @self.crawler.router.default_handler
         async def request_handler(context: PlaywrightCrawlingContext) -> None:

--- a/tests/unit/test_website_etl.py
+++ b/tests/unit/test_website_etl.py
@@ -30,15 +30,17 @@ class TestWebsiteETL(IsolatedAsyncioTestCase):
                 "title": "Example",
             }
         ]
-        
+
         # Mock the CrawleeClient class instead of the instance
-        with patch('hivemind_etl.website.website_etl.CrawleeClient') as MockCrawleeClient:
+        with patch(
+            "hivemind_etl.website.website_etl.CrawleeClient"
+        ) as MockCrawleeClient:
             mock_client_instance = AsyncMock()
             mock_client_instance.crawl.return_value = mocked_data
             MockCrawleeClient.return_value = mock_client_instance
-            
+
             extracted_data = await self.website_etl.extract(urls)
-            
+
             self.assertEqual(extracted_data, mocked_data)
             MockCrawleeClient.assert_called_once()
             mock_client_instance.crawl.assert_awaited_once_with(links=urls)


### PR DESCRIPTION
the reason is, crawlee is caching all the requests and everytime it's being re-initialized, it would re-fetch previous enqueud links and not the new ones
still no good way of removing the request_queue is not provided by crawlee community.