### PR TITLE
feat: trying to fix the no doc_ref_id error on loading documents!

### DIFF
--- a/hivemind_etl/mediawiki/etl.py
+++ b/hivemind_etl/mediawiki/etl.py
@@ -42,9 +42,11 @@ class MediawikiETL:
         documents: list[Document] = []
         for page in pages:
             try:
+                # Generate a ref_doc_id if needed for newer llama-index versions
+                doc_id = page.page_id
                 documents.append(
                     Document(
-                        doc_id=page.page_id,
+                        doc_id=doc_id,
                         text=page.revision.text,
                         metadata={
                             "title": page.title,
@@ -57,6 +59,7 @@ class MediawikiETL:
                             "contributor_user_id": page.revision.contributor.user_id,
                             "sha1": page.revision.sha1,
                             "model": page.revision.model,
+                            "ref_doc_id": doc_id,  # Add ref_doc_id to metadata
                         },
                         excluded_embed_metadata_keys=[
                             "namespace",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dotenv>=1.0.0, <2.0.0
-tc-hivemind-backend==1.4.0
+tc-hivemind-backend==1.4.2.post2
 llama-index-storage-docstore-redis==0.1.2
 llama-index-storage-docstore-mongodb==0.1.3
 crawlee[playwright]==0.3.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency version for `tc-hivemind-backend` to 1.4.2.post2.

- **Refactor**
  - Improved document metadata structure by including a reference document ID in both the document identifier and metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->