### PR TITLE
feat: mediaWiki load task timeout increase!

### DIFF
--- a/hivemind_etl/mediawiki/workflows.py
+++ b/hivemind_etl/mediawiki/workflows.py
@@ -82,7 +82,7 @@ class LoadMediaWikiWorkflow:
         await workflow.execute_activity(
             load_mediawiki_data,
             mediawiki_platform,
-            start_to_close_timeout=timedelta(hours=3),
+            start_to_close_timeout=timedelta(days=3),
             retry_policy=RetryPolicy(
                 initial_interval=timedelta(minutes=1),
                 maximum_attempts=3,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the maximum execution time for loading MediaWiki data, allowing the process to run for up to 3 days instead of 3 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->