### PR TITLE
feat: limit batch size to 1!

### DIFF
--- a/hivemind_etl/mediawiki/etl.py
+++ b/hivemind_etl/mediawiki/etl.py
@@ -103,7 +103,7 @@ class MediawikiETL:
         )
         
         # Process batches in parallel using ThreadPoolExecutor
-        batch_size = 1000
+        batch_size = 1
         batches = [documents[i:i + batch_size] for i in range(0, len(documents), batch_size)]
         
         with ThreadPoolExecutor(max_workers=10) as executor:


### PR DESCRIPTION
As a temporary fix to llama-index first loading into vectorstore issue, we limit the batch size to 1.
